### PR TITLE
Return object response data after login

### DIFF
--- a/src/RocketChatUser.php
+++ b/src/RocketChatUser.php
@@ -41,7 +41,7 @@ class User extends Client {
 				Request::ini( $tmp );
 			}
 			$this->id = $response->body->data->userId;
-			return true;
+			return $response->body->data;
 		} else {
 			echo( $response->body->message . "\n" );
 			return false;


### PR DESCRIPTION
Why returning `true` when somebody may need more information for example `authToken` ?
The returned object is different from `false` so I think it will be fine returning the object `$response->body->data`.