### PR TITLE
Ability to set api host in constructor

### DIFF
--- a/src/RocketChatClient.php
+++ b/src/RocketChatClient.php
@@ -8,8 +8,15 @@ class Client{
 
 	public $api;
 
-	function __construct(){
-		$this->api = ROCKET_CHAT_INSTANCE . REST_API_ROOT;
+	public static $apiUrl;
+
+	function __construct($rocketChatApiUrl = null){
+        if (empty($rocketChatApiUrl)) {
+            $this->api = static::$apiUrl ?: ROCKET_CHAT_INSTANCE . REST_API_ROOT;
+        } else {
+            static::$apiUrl = $rocketChatApiUrl;
+            $this->api = $rocketChatApiUrl;
+        }
 
 		// set template request to send and expect JSON
 		$tmp = Request::init()


### PR DESCRIPTION
I think it will be better to configure api host in the constructor for not using constants. After this PR the initialization of Client can be like this:

```php
$client = new Client('https://demo.rocket.chat/api/v1/');
```

But it is still possible to use it as usual. 